### PR TITLE
feat: implementa rota de contratos pendentes para motoristas

### DIFF
--- a/backend/src/main/java/br/com/driveflex/api/Main.java
+++ b/backend/src/main/java/br/com/driveflex/api/Main.java
@@ -33,6 +33,8 @@ public class Main {
         // For DELETE /api/users/{id}, the context path needs to be just /api/users
         // The handler itself will parse the {id} from the request URI
         server.createContext("/api/users/", new UserDeleteHandler()); 
+        server.createContext("/api/contracts/pending", new PendingContractsHandler());
+
 
         server.setExecutor(null);
         server.start();
@@ -41,6 +43,7 @@ public class Main {
         System.out.println("[INFO] Rota registrada: /auth/register");
         System.out.println("[INFO] Rota registrada: /auth/login");
         System.out.println("[INFO] Rota registrada: /api/contracts/hire");
+        System.out.println("[INFO] Rota registrada: GET /api/contracts/pending");
         System.out.println("[INFO] Rota registrada: GET /api/users (List all users)");
         System.out.println("[INFO] Rota registrada: DELETE /api/users/{id} (Delete user)");
         System.out.println("[INFO] Pronto para receber conexões.");

--- a/backend/src/main/java/br/com/driveflex/api/PendingContractsHandler.java
+++ b/backend/src/main/java/br/com/driveflex/api/PendingContractsHandler.java
@@ -1,0 +1,113 @@
+package br.com.driveflex.api;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+
+import br.com.driveflex.model.Contract;
+import br.com.driveflex.model.User;
+import br.com.driveflex.repository.ContractRepository;
+import br.com.driveflex.repository.UserRepository;
+import br.com.driveflex.security.JwtUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Handler responsável por listar os contratos pendentes de um motorista.
+ * Rota esperada: GET /api/contracts/pending
+ */
+public class PendingContractsHandler implements HttpHandler {
+
+    private final UserRepository userRepository = new UserRepository();
+    private final ContractRepository contractRepository = new ContractRepository();
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(LocalDateTime.class, new JsonSerializer<LocalDateTime>() {
+                @Override
+                public JsonElement serialize(LocalDateTime src, Type typeOfSrc, JsonSerializationContext context) {
+                    return new JsonPrimitive(src.toString());
+                }
+            })
+            .create();
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        // 1. Garantir que apenas GET é aceito
+        if (!"GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+            sendResponse(exchange, 405, "{\"error\": \"Método não permitido. Use GET.\"}");
+            return;
+        }
+
+        // 2. Extração e Validação do Token JWT (Copiado do padrão do projeto)
+        String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            sendResponse(exchange, 401, "{\"error\": \"Token JWT ausente ou malformatado.\"}");
+            return;
+        }
+
+        String token = authHeader.substring(7); // Remove "Bearer "
+        String subjectIdString;
+        try {
+            subjectIdString = JwtUtils.validateTokenAndGetSubject(token);
+        } catch (ExpiredJwtException e) {
+            sendResponse(exchange, 401, "{\"error\": \"Token JWT expirado.\"}");
+            return;
+        } catch (SignatureException e) {
+            sendResponse(exchange, 401, "{\"error\": \"Token JWT inválido.\"}");
+            return;
+        } catch (Exception e) {
+            sendResponse(exchange, 401, "{\"error\": \"Falha na validação do token JWT.\"}");
+            return;
+        }
+        
+        UUID driverId;
+        try {
+            driverId = UUID.fromString(subjectIdString);
+        } catch (IllegalArgumentException e) {
+             sendResponse(exchange, 400, "{\"error\": \"ID do usuário inválido no token.\"}");
+             return;
+        }
+
+        try {
+            // 3. Validar se o usuário autenticado tem papel (role) de motorista
+            Optional<User> driverOpt = userRepository.findById(driverId);
+            if (driverOpt.isEmpty() || !driverOpt.get().getRole().equalsIgnoreCase("DRIVER")) {
+                sendResponse(exchange, 403, "{\"error\": \"Acesso negado. Apenas motoristas podem visualizar contratos pendentes.\"}");
+                return;
+            }
+
+            // 4. Buscar contratos pendentes utilizando o repositório
+            List<Contract> pendingContracts = contractRepository.findPendingByDriverId(driverId);
+
+            // 5. Converter para JSON e retornar Status 200
+            String jsonResponse = gson.toJson(pendingContracts);
+            sendResponse(exchange, 200, jsonResponse);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            sendResponse(exchange, 500, "{\"error\": \"Erro interno no servidor ao listar contratos: " + e.getMessage() + "\"}");
+        }
+    }
+
+    private void sendResponse(HttpExchange exchange, int statusCode, String response) throws IOException {
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/backend/src/main/java/br/com/driveflex/repository/ContractRepository.java
+++ b/backend/src/main/java/br/com/driveflex/repository/ContractRepository.java
@@ -5,6 +5,8 @@ import br.com.driveflex.model.Contract;
 
 import java.sql.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -86,5 +88,43 @@ public class ContractRepository {
             throw new RuntimeException("Erro ao buscar contrato por ID", e);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Busca todos os contratos pendentes para um motorista específico.
+     * @param driverId O ID do motorista.
+     * @return Lista de contratos com status 'PENDING'.
+     */
+    public List<Contract> findPendingByDriverId(UUID driverId) {
+        String sql = "SELECT * FROM contracts WHERE driver_id = ? AND status = 'PENDING';";
+        List<Contract> contracts = new ArrayList<>();
+
+        try (Connection conn = DatabaseConfig.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setObject(1, driverId);
+
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    Contract contract = new Contract();
+                    contract.setId((UUID) rs.getObject("id"));
+                    contract.setClientId((UUID) rs.getObject("client_id"));
+                    contract.setDriverId((UUID) rs.getObject("driver_id"));
+                    contract.setStatus(rs.getString("status"));
+                    contract.setStartTime(rs.getTimestamp("start_time").toLocalDateTime());
+                    
+                    Timestamp endTimeStamp = rs.getTimestamp("end_time");
+                    contract.setEndTime(endTimeStamp != null ? endTimeStamp.toLocalDateTime() : null);
+                    
+                    contract.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
+                    contract.setUpdatedAt(rs.getTimestamp("updated_at").toLocalDateTime());
+
+                    contracts.add(contract);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao buscar contratos pendentes do motorista", e);
+        }
+        return contracts;
     }
 }


### PR DESCRIPTION
 O que foi feito?
Esta PR atende ao requisito de permitir que os motoristas visualizem as propostas de contrato que foram direcionadas a eles e que estão aguardando resposta.

Foi implementado de ponta a ponta o novo endpoint GET /api/contracts/pending, incluindo a validação de segurança via Token JWT, a consulta nativa no banco de dados e a serialização correta das datas.

 Detalhes Técnicos
Nova Rota: Mapeamento de /api/contracts/pending no Main.java.

Segurança (RBAC): O PendingContractsHandler.java agora extrai o ID do usuário diretamente do JWT e valida se o dono do token possui a role "DRIVER". Retorna 403 Forbidden caso contrário.

Banco de Dados: Criação do método findPendingByDriverId(UUID driverId) no ContractRepository.java, fazendo a busca filtrada por driver_id = ? AND status = 'PENDING'.

Correção de Serialização: Implementação de um GsonBuilder customizado com TypeAdapter para converter corretamente os campos LocalDateTime (startTime e endTime) para String no retorno do JSON, evitando o erro clássico de reflexão do Java.